### PR TITLE
Do not add CRC to downlinks in TTN transport

### DIFF
--- a/mp_pkt_fwd/src/ttn_transport.c
+++ b/mp_pkt_fwd/src/ttn_transport.c
@@ -169,6 +169,7 @@ void ttn_downlink(Router__DownlinkMessage *msg, __attribute__ ((unused)) void *a
 			    buff_index += j;
 			}
 		    }
+		    txpkt.no_crc = 1;
 		    txpkt.freq_hz = gtw->frequency;
 		    txpkt.rf_chain = gtw->rf_chain;
 		    txpkt.rf_power = gtw->power - antenna_gain;


### PR DESCRIPTION
CRC should not be added to downlinks, following the LoRaWAN specification. More details and discussion can be found in [this issue](https://github.com/TheThingsProducts/gateway/issues/23).

With this addition, for downlinks received through `ttn` transport, CRC is explicitly removed from the packet before being transmitted.