### PR TITLE
Update location of WiringPi

### DIFF
--- a/mp_pkt_fwd/build-pi.sh
+++ b/mp_pkt_fwd/build-pi.sh
@@ -8,11 +8,11 @@ INSTALL_DIR="/opt/ttn-gateway"
 mkdir -p $INSTALL_DIR/dev
 cd $INSTALL_DIR/dev
 
-if [ ! -d wiringPi ]; then
-    git clone git://git.drogon.net/wiringPi  || { echo 'Cloning wiringPi failed.' ; exit 1; }
-    cd wiringPi
+if [ ! -d WiringPi ]; then
+    git clone https://github.com/WiringPi/WiringPi.git  || { echo 'Cloning wiringPi failed.' ; exit 1; }
+    cd WiringPi
 else
-    cd wiringPi
+    cd WiringPi
     git reset --hard
     git pull
 fi


### PR DESCRIPTION
WiringPI is now deprecated and the official repository removed. Details at http://wiringpi.com/news/ . A community maintained mirror is available for now. The install script has been updated to use this instead.