### PR TITLE
Memory leak in semtech_transport

### DIFF
--- a/mp_pkt_fwd/src/semtech_transport.c
+++ b/mp_pkt_fwd/src/semtech_transport.c
@@ -1459,6 +1459,8 @@ void semtech_upstream(void *pic) {
 		buff_index -= 8; /* removes "rxpk":[ */
 	    } else {
 		/* all packet have been filtered out and no report, restart loop */
+		free(entry);
+		MSG("WARN: [up] all packet have been filtered out with no report.\n");
 		continue;
 	    }
 	} else {


### PR DESCRIPTION
Hello, I found and fixed a memory leak in the semtech transport.

This exhausted the 1G RAM on the gateway with hundreds of packets/min within a week.

In my case, about 1/3 of the packets were filtered-out, thus contributing to memory leaks.